### PR TITLE
Corrected the syntax for 'cordova plugin add'

### DIFF
--- a/README.md
+++ b/README.md
@@ -16,7 +16,7 @@ Create a new Cordova Project
 Install the plugin
 
     $ cd hello
-    $ cordova plugin install ../cordova-plugin-hello
+    $ cordova plugin add ../cordova-plugin-hello
     
 
 Edit `www/js/index.js` and add the following code inside `onDeviceReady`


### PR DESCRIPTION
According to the docs - http://cordova.apache.org/docs/en/edge/guide_cli_index.md.html#The%20Command-line%20Interface - the correct syntax is ```cordova plugin add``` not ```cordova plugin install```