### PR TITLE
Create package.json

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,0 +1,30 @@
+{
+  "name": "cordova-plugin-hello",
+  "version": "0.1.0",
+  "description": "A sample for a new cordova plugin",
+  "cordova": {
+    "id": "cordova-plugin-hello",
+    "platforms": [
+      "android",
+      "ios",
+      "wp7"
+    ]
+  },
+  "repository": {
+    "type": "git",
+    "url": "git+https://github.com/don/cordova-plugin-hello.git"
+  },
+  "keywords": [
+    "cordova",
+    "plugin",
+    "hello",
+    "ecosystem:cordova",
+    "cordova-android"
+  ],
+  "author": "Don Coleman",
+  "license": "MIT",
+  "bugs": {
+    "url": "https://github.com/don/cordova-plugin-hello/issues"
+  },
+  "homepage": "https://github.com/don/cordova-plugin-hello#readme"
+}


### PR DESCRIPTION
After update of npm to the new version(5.0.3), cordova can't install this plugin, it requires a package.json file: 

Error: Failed to fetch plugin https://github.com/don/cordova-plugin-hello.git via registry.
Probably this is either a connection problem, or plugin spec is incorrect.
Check your connection and plugin name/version/URL.
Error: npm: Command failed with exit code 254 Error output:
npm ERR! path /home/andreussi/.npm/_cacache/tmp/git-clone-0af213cb/package.json
npm ERR! code ENOENT
npm ERR! errno -2
npm ERR! syscall open
npm ERR! enoent ENOENT: no such file or directory, open '/home/andreussi/.npm/_cacache/tmp/git-clone-0af213cb/package.json'
npm ERR! enoent This is related to npm not being able to find a file.
npm ERR! enoent 

npm ERR! A complete log of this run can be found in:
npm ERR!     /home/andreussi/.npm/_logs/2017-07-26T23_33_49_819Z-debug.log

I also have a plugin which can't be installed because of the non-existance of this file, i've added the package.json as i proposed, and it works like a charm

PS: Thank you so much for publish this plugin, it helped me a lot!